### PR TITLE
adapt asgi.py to new version of django channels

### DIFF
--- a/_1327/asgi.py
+++ b/_1327/asgi.py
@@ -1,7 +1,10 @@
 import os
 
-from channels.asgi import get_channel_layer
+from channels.routing import get_default_application
+
+import django
+
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "_1327.settings")
-
-channel_layer = get_channel_layer()
+django.setup()
+application = get_default_application()


### PR DESCRIPTION
In our last update of django channels, we forgot to adapt the file `asgi.py`.
This version now works very nice in a deployed version of 1327.